### PR TITLE
Add centralized Slack notifier via /api/notify-lead

### DIFF
--- a/frontend/src/components/ConsultationForm.tsx
+++ b/frontend/src/components/ConsultationForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Button } from '@/components/ui/Button';
+import { notifyLead, utmFromLocation } from '@/lib/notifyLead';
 
 interface ConsultationFormProps {
   onSuccess?: () => void;
@@ -47,6 +48,14 @@ export function ConsultationForm({ onSuccess }: ConsultationFormProps) {
       }
 
       setSuccess(true);
+      // Fire-and-forget Slack notifier
+      try {
+        const page_url = typeof window !== 'undefined' ? window.location.href : '';
+        const payload = { ...formData, page_url, ...utmFromLocation() };
+        notifyLead('consultation', payload);
+      } catch (e) {
+        console.warn('notifyLead skipped', e);
+      }
       if (onSuccess) {
         setTimeout(onSuccess, 2000);
       }

--- a/frontend/src/lib/notifyLead.ts
+++ b/frontend/src/lib/notifyLead.ts
@@ -1,0 +1,24 @@
+export function utmFromLocation() {
+  if (typeof window === 'undefined') return {} as Record<string, string>;
+  const q = new URLSearchParams(window.location.search);
+  return {
+    utm_source: q.get('utm_source') || '',
+    utm_medium: q.get('utm_medium') || '',
+    utm_campaign: q.get('utm_campaign') || '',
+    utm_term: q.get('utm_term') || '',
+    utm_content: q.get('utm_content') || '',
+  } as Record<string, string>;
+}
+
+export async function notifyLead(context: string, payload: Record<string, any>) {
+  try {
+    await fetch('https://utlyzecom.vercel.app/api/notify-lead', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ context, payload }),
+    });
+  } catch (e) {
+    console.warn('notifyLead failed', e);
+  }
+}
+


### PR DESCRIPTION
This PR adds a fire-and-forget Slack notifier that posts to our centralized endpoint (utlyzecom.vercel.app/api/notify-lead). It sends relevant form payload + page_url + UTM, without blocking UX. After utlyze.com is reattached, we can switch endpoint to utlyze.com/api/notify-lead.